### PR TITLE
Allow for non wildcard origin

### DIFF
--- a/lib/middleware/cors.js
+++ b/lib/middleware/cors.js
@@ -13,7 +13,8 @@
 
 function cors() {
   return async (req, res) => {
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    let origin = req.headers.origin != null ? req.headers.origin : '*'
+    res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Access-Control-Allow-Credentials', 'true');
     res.setHeader(
       'Access-Control-Allow-Methods',


### PR DESCRIPTION
This lets the browser (google chrome) accept a response with an Access-Control-Allow-Origin header for a request that included credentials.