### PR TITLE
Don't return internal error when body parser fails

### DIFF
--- a/lib/middleware/bodyparser.js
+++ b/lib/middleware/bodyparser.js
@@ -26,6 +26,9 @@ function bodyParser(options) {
     try {
       req.resume();
       req.body = await parseBody(req, opt);
+    } catch (err) {
+      err.statusCode = 400;
+      throw err;
     } finally {
       req.pause();
     }


### PR DESCRIPTION
For incorrect requests, bweb will return 400 instead of 500. Also because `statusCode` exists Errors will no logger be part of the error logs.