### PR TITLE
fileServer: refresh fs.stat if useIndex: true

### DIFF
--- a/lib/middleware/file.js
+++ b/lib/middleware/file.js
@@ -83,6 +83,7 @@ function fileServer(options) {
       }
 
       file = index;
+      stat = await call(fs.stat, file);
     }
 
     if (jail)


### PR DESCRIPTION
If using fileServer middleware with useIndex (which auto translates `/` to `/index.html`) we need to refresh the `stat` properties of the new target file, otherwise `stat.isDirectory()` will return true downstream ,leading to a 404